### PR TITLE
Set "Payment methods enabled" in default scope only

### DIFF
--- a/etc/adminhtml/system/adyen_payment_methods.xml
+++ b/etc/adminhtml/system/adyen_payment_methods.xml
@@ -17,8 +17,8 @@
         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
         <comment> <![CDATA[<p>By enabling your payment methods here, we can automatically retrieve the payment preferences already defined in your Customer Area.</p>]]>
         </comment>
-        <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1"
-               showInStore="1">
+        <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="0"
+               showInStore="0">
             <label>Payment methods enabled</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <backend_model>Adyen\Payment\Model\Config\Backend\PaymentMethodsStatus</backend_model>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->
**Description**
The configuration setting `Payment methods enabled` is shown across all scopes. No matter what scope is selected, the underlying backend model `Adyen\Payment\Model\Config\Backend\PaymentMethodsStatus` is **always** updating the default scope for the single payment methods.  
This leads to inconsistencies between `payment/adyen_abstract/payment_methods_active` and all the single payment method configurations.

* Set `Payment methods enabled` to `Yes` in `Default` scope
* Having a `Website A` and a `Website B` in place
* Set ``Payment methods enabled` to `Yes` in `Website A` scope
**Expected Result**
* Payment methods are still active in `Website B`
**Actual Result**
* Payment methods are deactived in  `Website B` as well

Showing the configuration setting only in `Default` scope won't lead to such inconsistencies.

**Tested scenarios**
* `Stores > Configuration > Sales > Adyen > Accepting Payments > Payment methods > Payment methods enabled` is a global setting